### PR TITLE
ci: Run deploy workflow weekly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: "0 5 * * 0"
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Currently the deploy workflow is only run on push to this repo or when manually triggered.
This leads to a quite outdated deploy.

By running this weekly (arbitrarily chosen 5AM Sunday) we get a reasonably up-to-date deploy for our api-docs.

In the future we might consider a different approach but for now this should be sufficient.